### PR TITLE
Add `ColorLike`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lakuna/ugl",
-	"version": "16.0.0",
+	"version": "16.1.0",
 	"description": "A lightweight WebGL2 library.",
 	"keywords": [
 		"front-end"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export type { default as Box } from "#types/Box";
 export type { default as MeasuredIterable } from "#types/MeasuredIterable";
 export type { FloatTypedArray, IntTypedArray, TypedArray, UintTypedArray } from "#types/TypedArray";
-export { default as Color } from "#utility/Color";
+export { default as Color, type ColorLike } from "#utility/Color";
 export { default as Cubemap, CubemapMip } from "#textures/Cubemap";
 export {
 	default as Texture, Mip, Mipmap, type MipSource, MipmapTarget, TextureBaseFormat,

--- a/src/utility/Color.ts
+++ b/src/utility/Color.ts
@@ -1,3 +1,6 @@
+/** A representation of a color. */
+export type ColorLike = [number, number, number, number] | Color;
+
 /**
  * The piecewise equation used internally for calculating relative luminance.
  * @param c The value passed to the piecewise function (red, green, or blue).
@@ -7,6 +10,34 @@ function luminancePiecewise(c: number) {
 	return c > 0.04045
 		? ((c + 0.055) / 1.055) ** 2.4
 		: c / 12.92
+}
+
+/**
+ * Returns the luminance of a color.
+ * @param color The color.
+ * @returns The luminance.
+ * @see [Algorithm](https://www.w3.org/WAI/GL/wiki/Relative_luminance)
+ */
+function luminance(color: ColorLike): number {
+	return 0.2126 * luminancePiecewise(color[0])
+		+ 0.7152 * luminancePiecewise(color[1])
+		+ 0.0722 * luminancePiecewise(color[2]);
+}
+
+/**
+ * Calculates the contrast ratio between two colors.
+ * @param a The first color.
+ * @param b The second color.
+ * @returns The contrast ratio between the colors.
+ * @see [Algorithm](https://www.w3.org/WAI/GL/wiki/Contrast_ratio)
+ */
+function contrast(a: ColorLike, b: ColorLike): number {
+	const l1: number = luminance(a);
+	const l2: number = luminance(b);
+
+	return l1 > l2
+		? (l1 + 0.05) / (l2 + 0.05)
+		: (l2 + 0.05) / (l1 + 0.05);
 }
 
 /** A color. */
@@ -83,23 +114,16 @@ export default class Color extends Float32Array {
 	 * @see [Algorithm](https://www.w3.org/WAI/GL/wiki/Relative_luminance)
 	 */
 	public get luminance(): number {
-		return 0.2126 * luminancePiecewise(this.r)
-			+ 0.7152 * luminancePiecewise(this.g)
-			+ 0.0722 * luminancePiecewise(this.b);
+		return luminance(this);
 	}
 
 	/**
 	 * Calculates the contrast ratio between this color and another.
-	 * @param c The other color.
+	 * @param color The other color.
 	 * @returns The contrast ratio between the colors.
 	 * @see [Algorithm](https://www.w3.org/WAI/GL/wiki/Contrast_ratio)
 	 */
-	public contrast(c: Color): number {
-		const l1: number = this.luminance;
-		const l2: number = c.luminance;
-
-		return l1 > l2
-			? (l1 + 0.05) / (l2 + 0.05)
-			: (l2 + 0.05) / (l1 + 0.05);
+	public contrast(color: ColorLike): number {
+		return contrast(this, color);
 	}
 }

--- a/src/webgl/Context.ts
+++ b/src/webgl/Context.ts
@@ -1,5 +1,5 @@
 import type Box from "#types/Box";
-import type Color from "#utility/Color";
+import type { ColorLike } from "#utility/Color";
 
 /** A canvas. */
 export type Canvas = HTMLCanvasElement | OffscreenCanvas;
@@ -968,7 +968,7 @@ export default class Context {
 	 * @param depth The value to clear the depth buffer to, if any.
 	 * @param stencil The value to clear the stencil buffer to, if any.
 	 */
-	public clear(color?: Color | undefined, depth?: number | undefined, stencil?: number | undefined): void {
+	public clear(color?: ColorLike | undefined, depth?: number | undefined, stencil?: number | undefined): void {
 		let colorBit = 0;
 		if (color) {
 			this.internal.clearColor(color[0] ?? 0, color[1] ?? 0, color[2] ?? 0, color[3] ?? 0);


### PR DESCRIPTION
# Pull Request

## Description

Adds `ColorLike`, which allows 4-tuples to be used in place of `Color`s.

## Relevant Issues

List relevant issues here, if any exist.

N/A

# Details

N/A
